### PR TITLE
refactor: modal navigation

### DIFF
--- a/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
@@ -11,6 +11,13 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Browse Apps View', () => {
+    beforeAll(() => {
+        // Testing environment does not support the <dialog> component yet so it has to mocked
+        // linked issue: https://github.com/jsdom/jsdom/issues/3294
+        HTMLDialogElement.prototype.showModal = jest.fn()
+        HTMLDialogElement.prototype.close = jest.fn()
+    })
+
     it('renders Browse Apps View', async () => {
         const user = userEvent.setup()
         const {
@@ -60,6 +67,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
             findByPlaceholderText,
             container,
             findByTestId,
+            // debug
         } = render(
             <CommandPalette
                 apps={testApps}
@@ -87,6 +95,9 @@ describe('Command Palette - List View - Browse Apps View', () => {
         expect(listItems[0].querySelector('span')).toHaveTextContent(
             'Test App 1'
         )
+        listItems[0].focus()
+
+        // debug()
 
         await user.keyboard('{ArrowDown}')
         expect(listItems[0]).not.toHaveClass('highlighted')
@@ -94,6 +105,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         expect(listItems[1].querySelector('span')).toHaveTextContent(
             'Test App 2'
         )
+        listItems[1].focus()
 
         await user.keyboard('{ArrowDown}')
         expect(listItems[1]).not.toHaveClass('highlighted')
@@ -101,6 +113,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         expect(listItems[2].querySelector('span')).toHaveTextContent(
             'Test App 3'
         )
+        listItems[2].focus()
 
         await user.keyboard('{ArrowUp}')
         expect(listItems[2]).not.toHaveClass('highlighted')
@@ -108,6 +121,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         expect(listItems[1].querySelector('span')).toHaveTextContent(
             'Test App 2'
         )
+        listItems[1].focus()
 
         // filter items view
         await user.type(searchField, 'Test App')

--- a/components/header-bar/src/command-palette/__tests__/browse-commands-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-commands-view.test.js
@@ -8,6 +8,12 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Browse Commands', () => {
+    beforeAll(() => {
+        // Testing environment does not support the <dialog> component yet so it has to mocked
+        // linked issue: https://github.com/jsdom/jsdom/issues/3294
+        HTMLDialogElement.prototype.showModal = jest.fn()
+        HTMLDialogElement.prototype.close = jest.fn()
+    })
     it('renders Browse Commands View', async () => {
         const user = userEvent.setup()
         const {
@@ -42,10 +48,11 @@ describe('Command Palette - List View - Browse Commands', () => {
             'Test Command 1'
         )
         expect(listItem).toHaveClass('highlighted')
+        listItem.focus()
 
         // Esc key goes back to default view
         await user.keyboard('{Escape}')
-        // expect(queryByText(/All Commands/i)).not.toBeInTheDocument()
+        expect(queryByText(/All Commands/i)).not.toBeInTheDocument()
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
     })
 })

--- a/components/header-bar/src/command-palette/__tests__/browse-shortcuts-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-shortcuts-view.test.js
@@ -8,6 +8,12 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Browse Shortcuts', () => {
+    beforeAll(() => {
+        // Testing environment does not support the <dialog> component yet so it has to mocked
+        // linked issue: https://github.com/jsdom/jsdom/issues/3294
+        HTMLDialogElement.prototype.showModal = jest.fn()
+        HTMLDialogElement.prototype.close = jest.fn()
+    })
     it('renders Browse Shortcuts View', async () => {
         const user = userEvent.setup()
         const {

--- a/components/header-bar/src/command-palette/__tests__/command-palette.test.js
+++ b/components/header-bar/src/command-palette/__tests__/command-palette.test.js
@@ -53,6 +53,12 @@ export const testShortcuts = [
 ]
 
 describe('Command Palette Component', () => {
+    beforeAll(() => {
+        // Testing environment does not support the <dialog> component yet so it has to mocked
+        // linked issue: https://github.com/jsdom/jsdom/issues/3294
+        HTMLDialogElement.prototype.showModal = jest.fn()
+        HTMLDialogElement.prototype.close = jest.fn()
+    })
     it('renders bare default view when Command Palette is opened', async () => {
         const user = userEvent.setup()
         const { getByTestId, queryByTestId, getByPlaceholderText } = render(

--- a/components/header-bar/src/command-palette/__tests__/command-palette.test.js
+++ b/components/header-bar/src/command-palette/__tests__/command-palette.test.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
 import { CommandPaletteContextProvider } from '../context/command-palette-context.js'
-import { MIN_APPS_NUM } from '../hooks/use-navigation.js'
+import { MIN_APPS_NUM } from '../utils/constants.js'
 
 const CommandPaletteProviderWrapper = ({ children }) => {
     return (

--- a/components/header-bar/src/command-palette/__tests__/home-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/home-view.test.js
@@ -12,6 +12,12 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - Home View', () => {
+    beforeAll(() => {
+        // Testing environment does not support the <dialog> component yet so it has to mocked
+        // linked issue: https://github.com/jsdom/jsdom/issues/3294
+        HTMLDialogElement.prototype.showModal = jest.fn()
+        HTMLDialogElement.prototype.close = jest.fn()
+    })
     it('shows the full default view upon opening the Command Palette', async () => {
         const user = userEvent.setup()
         const {

--- a/components/header-bar/src/command-palette/__tests__/search-results.test.js
+++ b/components/header-bar/src/command-palette/__tests__/search-results.test.js
@@ -11,6 +11,12 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Search Results', () => {
+    beforeAll(() => {
+        // Testing environment does not support the <dialog> component yet so it has to mocked
+        // linked issue: https://github.com/jsdom/jsdom/issues/3294
+        HTMLDialogElement.prototype.showModal = jest.fn()
+        HTMLDialogElement.prototype.close = jest.fn()
+    })
     it('filters for one item and handles navigation of singular item list', async () => {
         const user = userEvent.setup()
         const { getByPlaceholderText, queryAllByTestId, container } = render(

--- a/components/header-bar/src/command-palette/command-palette.js
+++ b/components/header-bar/src/command-palette/command-palette.js
@@ -55,7 +55,7 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
 
     const handleVisibilityToggle = useCallback(
         () => setModalOpen((open) => !open),
-        []
+        [setModalOpen]
     )
 
     useEffect(() => {
@@ -97,7 +97,7 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
             document.removeEventListener('keydown', handleKeyDown)
             document.removeEventListener('click', onDocClick)
         }
-    }, [goToDefaultView])
+    }, [goToDefaultView, setModalOpen, modalRef])
 
     return (
         <div ref={containerEl} data-test="headerbar" className="headerbar">

--- a/components/header-bar/src/command-palette/context/command-palette-context.js
+++ b/components/header-bar/src/command-palette/context/command-palette-context.js
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types'
 import React, { createContext, useContext, useState } from 'react'
+import { HOME_VIEW } from '../utils/constants.js'
 
 const commandPaletteContext = createContext()
 
 export const CommandPaletteContextProvider = ({ children }) => {
     const [filter, setFilter] = useState('')
     const [highlightedIndex, setHighlightedIndex] = useState(0)
-    const [currentView, setCurrentView] = useState('home')
+    const [currentView, setCurrentView] = useState(HOME_VIEW)
     // home view sections
     const [activeSection, setActiveSection] = useState(null)
 

--- a/components/header-bar/src/command-palette/hooks/use-actions.js
+++ b/components/header-bar/src/command-palette/hooks/use-actions.js
@@ -7,6 +7,7 @@ import {
 } from '@dhis2/ui-icons'
 import React, { useMemo } from 'react'
 import i18n from '../../locales/index.js'
+import { APPS, COMMANDS, LOGOUT, SHORTCUTS } from '../utils/constants.js'
 import { MIN_APPS_NUM } from './use-navigation.js'
 
 export const useAvailableActions = ({ apps, shortcuts, commands }) => {
@@ -14,7 +15,7 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
         const actionsArray = []
         if (apps?.length > MIN_APPS_NUM) {
             actionsArray.push({
-                type: 'apps',
+                type: APPS,
                 title: i18n.t('Browse apps'),
                 icon: <IconApps16 color={colors.grey700} />,
                 dataTest: 'headerbar-browse-apps',
@@ -22,7 +23,7 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
         }
         if (commands?.length > 0) {
             actionsArray.push({
-                type: 'commands',
+                type: COMMANDS,
                 title: i18n.t('Browse commands'),
                 icon: <IconTerminalWindow16 color={colors.grey700} />,
                 dataTest: 'headerbar-browse-commands',
@@ -30,7 +31,7 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
         }
         if (shortcuts?.length > 0) {
             actionsArray.push({
-                type: 'shortcuts',
+                type: SHORTCUTS,
                 title: i18n.t('Browse shortcuts'),
                 icon: <IconRedo16 color={colors.grey700} />,
                 dataTest: 'headerbar-browse-shortcuts',
@@ -38,7 +39,7 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
         }
         // default logout action
         actionsArray.push({
-            type: 'logout',
+            type: LOGOUT,
             title: i18n.t('Logout'),
             icon: <IconLogOut16 color={colors.grey700} />,
             dataTest: 'headerbar-logout',

--- a/components/header-bar/src/command-palette/hooks/use-actions.js
+++ b/components/header-bar/src/command-palette/hooks/use-actions.js
@@ -7,8 +7,13 @@ import {
 } from '@dhis2/ui-icons'
 import React, { useMemo } from 'react'
 import i18n from '../../locales/index.js'
-import { APPS, COMMANDS, LOGOUT, SHORTCUTS } from '../utils/constants.js'
-import { MIN_APPS_NUM } from './use-navigation.js'
+import {
+    APPS,
+    COMMANDS,
+    LOGOUT,
+    MIN_APPS_NUM,
+    SHORTCUTS,
+} from '../utils/constants.js'
 
 export const useAvailableActions = ({ apps, shortcuts, commands }) => {
     const actions = useMemo(() => {

--- a/components/header-bar/src/command-palette/hooks/use-filter.js
+++ b/components/header-bar/src/command-palette/hooks/use-filter.js
@@ -1,5 +1,10 @@
 import { useMemo } from 'react'
 import { useCommandPaletteContext } from '../context/command-palette-context.js'
+import {
+    ALL_APPS_VIEW,
+    ALL_COMMANDS_VIEW,
+    ALL_SHORTCUTS_VIEW,
+} from '../utils/constants.js'
 import { filterItemsArray } from '../utils/filterItemsArray.js'
 
 export const useFilter = ({ apps, commands, shortcuts }) => {
@@ -10,11 +15,11 @@ export const useFilter = ({ apps, commands, shortcuts }) => {
     const filteredShortcuts = filterItemsArray(shortcuts, filter)
 
     const currentViewItemsArray = useMemo(() => {
-        if (currentView === 'apps') {
+        if (currentView === ALL_APPS_VIEW) {
             return filteredApps
-        } else if (currentView === 'commands') {
+        } else if (currentView === ALL_COMMANDS_VIEW) {
             return filteredCommands
-        } else if (currentView === 'shortcuts') {
+        } else if (currentView === ALL_SHORTCUTS_VIEW) {
             return filteredShortcuts
         } else {
             return filteredApps.concat(filteredCommands, filteredShortcuts)

--- a/components/header-bar/src/command-palette/hooks/use-grid.js
+++ b/components/header-bar/src/command-palette/hooks/use-grid.js
@@ -1,0 +1,62 @@
+import { useMemo } from 'react'
+import { useCommandPaletteContext } from '../context/command-palette-context.js'
+
+const useGrid = ({ rows, columns }) => {
+    const { highlightedIndex } = useCommandPaletteContext()
+    const rowIndexDifference = useMemo(() => columns - 1, [columns])
+
+    const firstIndexPerRowArray = useMemo(() => {
+        const arr = []
+        for (let i = 0; i < rows; i++) {
+            arr.push(i * columns)
+        }
+        return arr
+    }, [rows, columns])
+
+    const lastIndexPerRowArray = useMemo(() => {
+        return firstIndexPerRowArray.map((index) => index + rowIndexDifference)
+    }, [firstIndexPerRowArray, rowIndexDifference])
+
+    const activeRow = useMemo(() => {
+        let row = 0
+        for (let i = 0; i < rows; i++) {
+            if (highlightedIndex >= firstIndexPerRowArray[i]) {
+                row = i
+            }
+        }
+        return row
+    }, [rows, firstIndexPerRowArray, highlightedIndex])
+
+    const [rowFirstIndex, rowLastIndex] = useMemo(() => {
+        const row = activeRow
+        const rowFirstIndex = firstIndexPerRowArray[row]
+        const rowLastIndex = lastIndexPerRowArray[row]
+
+        return [rowFirstIndex, rowLastIndex]
+    }, [activeRow, firstIndexPerRowArray, lastIndexPerRowArray])
+
+    const nextLeftIndex = useMemo(() => {
+        return highlightedIndex > rowFirstIndex
+            ? highlightedIndex - 1
+            : rowLastIndex
+    }, [highlightedIndex, rowFirstIndex, rowLastIndex])
+
+    const nextRightIndex = useMemo(() => {
+        return highlightedIndex >= rowLastIndex
+            ? rowFirstIndex
+            : highlightedIndex + 1
+    }, [highlightedIndex, rowFirstIndex, rowLastIndex])
+
+    const lastRowFirstIndex = useMemo(() => {
+        return firstIndexPerRowArray[rows - 1]
+    }, [firstIndexPerRowArray, rows])
+
+    return {
+        nextLeftIndex,
+        nextRightIndex,
+        lastRowFirstIndex,
+        rows,
+    }
+}
+
+export default useGrid

--- a/components/header-bar/src/command-palette/hooks/use-list-navigation.js
+++ b/components/header-bar/src/command-palette/hooks/use-list-navigation.js
@@ -1,0 +1,33 @@
+import { useCallback } from 'react'
+import { useCommandPaletteContext } from '../context/command-palette-context.js'
+
+const useListNavigation = () => {
+    const { highlightedIndex, setHighlightedIndex } = useCommandPaletteContext()
+
+    const handleListNavigation = useCallback(
+        ({ event, listLength }) => {
+            const lastIndex = listLength - 1
+            switch (event.key) {
+                case 'ArrowDown':
+                    event.preventDefault()
+                    setHighlightedIndex(
+                        highlightedIndex >= lastIndex ? 0 : highlightedIndex + 1
+                    )
+                    break
+                case 'ArrowUp':
+                    event.preventDefault()
+                    setHighlightedIndex(
+                        highlightedIndex > 0 ? highlightedIndex - 1 : lastIndex
+                    )
+                    break
+                default:
+                    break
+            }
+        },
+        [highlightedIndex, setHighlightedIndex]
+    )
+
+    return handleListNavigation
+}
+
+export default useListNavigation

--- a/components/header-bar/src/command-palette/hooks/use-modal.js
+++ b/components/header-bar/src/command-palette/hooks/use-modal.js
@@ -7,13 +7,13 @@ const useModal = (modalRef) => {
         if (modalRef.current) {
             modalRef.current.showModal()
         }
-    }, [])
+    }, [modalRef])
 
     const handleCloseModal = useCallback(() => {
         if (modalRef.current) {
             modalRef.current.close()
         }
-    }, [])
+    }, [modalRef])
 
     useEffect(() => {
         if (modalOpen) {
@@ -21,7 +21,7 @@ const useModal = (modalRef) => {
         } else {
             handleCloseModal
         }
-    }, [modalOpen])
+    }, [modalOpen, handleCloseModal, handleOpenModal])
 
     return {
         modalOpen,

--- a/components/header-bar/src/command-palette/hooks/use-modal.js
+++ b/components/header-bar/src/command-palette/hooks/use-modal.js
@@ -1,0 +1,32 @@
+import { useCallback, useState, useEffect } from 'react'
+
+const useModal = (modalRef) => {
+    const [modalOpen, setModalOpen] = useState(false)
+
+    const handleOpenModal = useCallback(() => {
+        if (modalRef.current) {
+            modalRef.current.showModal()
+        }
+    }, [])
+
+    const handleCloseModal = useCallback(() => {
+        if (modalRef.current) {
+            modalRef.current.close()
+        }
+    }, [])
+
+    useEffect(() => {
+        if (modalOpen) {
+            handleOpenModal()
+        } else {
+            handleCloseModal
+        }
+    }, [modalOpen])
+
+    return {
+        modalOpen,
+        setModalOpen,
+    }
+}
+
+export default useModal

--- a/components/header-bar/src/command-palette/hooks/use-navigation.js
+++ b/components/header-bar/src/command-palette/hooks/use-navigation.js
@@ -1,15 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useCommandPaletteContext } from '../context/command-palette-context.js'
+import { ACTIONS_SECTION, GRID_SECTION, HOME_VIEW } from '../utils/constants.js'
+import useModal from './use-modal.js'
 
 export const GRID_ITEMS_LENGTH = 8
 export const MIN_APPS_NUM = GRID_ITEMS_LENGTH
 
-export const useNavigation = ({
-    setOpenModal,
-    itemsArray,
-    showGrid,
-    actionsLength,
-}) => {
+export const useNavigation = ({ itemsArray, showGrid, actionsLength }) => {
     const modalRef = useRef(null)
 
     const {
@@ -23,16 +20,18 @@ export const useNavigation = ({
         setActiveSection,
     } = useCommandPaletteContext()
 
+    const { modalOpen, setModalOpen } = useModal(modalRef)
+
     // highlight first item in filtered results
     useEffect(() => {
         setHighlightedIndex(0)
     }, [filter, setHighlightedIndex])
 
-    const defaultSection = showGrid ? 'grid' : 'actions'
+    const defaultSection = showGrid ? GRID_SECTION : ACTIONS_SECTION
 
     const goToDefaultView = useCallback(() => {
         setFilter('')
-        setCurrentView('home')
+        setCurrentView(HOME_VIEW)
         setActiveSection(defaultSection)
         setHighlightedIndex(0)
     }, [
@@ -85,7 +84,7 @@ export const useNavigation = ({
                 switch (event.key) {
                     case 'ArrowLeft':
                         event.preventDefault()
-                        if (activeSection === 'grid') {
+                        if (activeSection === GRID_SECTION) {
                             // row 1
                             if (highlightedIndex <= topRowLastIndex) {
                                 setHighlightedIndex(
@@ -106,7 +105,7 @@ export const useNavigation = ({
                         break
                     case 'ArrowRight':
                         event.preventDefault()
-                        if (activeSection === 'grid') {
+                        if (activeSection === GRID_SECTION) {
                             // row 1
                             if (highlightedIndex <= topRowLastIndex) {
                                 setHighlightedIndex(
@@ -127,18 +126,18 @@ export const useNavigation = ({
                         break
                     case 'ArrowDown':
                         event.preventDefault()
-                        if (activeSection === 'grid') {
+                        if (activeSection === GRID_SECTION) {
                             if (highlightedIndex >= lastRowFirstIndex) {
-                                setActiveSection('actions')
+                                setActiveSection(ACTIONS_SECTION)
                                 setHighlightedIndex(0)
                             } else {
                                 setHighlightedIndex(
                                     highlightedIndex + gridRowLength
                                 )
                             }
-                        } else if (activeSection === 'actions') {
+                        } else if (activeSection === ACTIONS_SECTION) {
                             if (highlightedIndex >= actionsLength - 1) {
-                                setActiveSection('grid')
+                                setActiveSection(GRID_SECTION)
                                 setHighlightedIndex(0)
                             } else {
                                 setHighlightedIndex(highlightedIndex + 1)
@@ -147,18 +146,18 @@ export const useNavigation = ({
                         break
                     case 'ArrowUp':
                         event.preventDefault()
-                        if (activeSection === 'grid') {
+                        if (activeSection === GRID_SECTION) {
                             if (highlightedIndex < lastRowFirstIndex) {
-                                setActiveSection('actions')
+                                setActiveSection(ACTIONS_SECTION)
                                 setHighlightedIndex(lastActionIndex)
                             } else {
                                 setHighlightedIndex(
                                     highlightedIndex - gridRowLength
                                 )
                             }
-                        } else if (activeSection === 'actions') {
+                        } else if (activeSection === ACTIONS_SECTION) {
                             if (highlightedIndex <= 0) {
-                                setActiveSection('grid')
+                                setActiveSection(GRID_SECTION)
                                 setHighlightedIndex(lastRowFirstIndex)
                             } else {
                                 setHighlightedIndex(highlightedIndex - 1)
@@ -169,7 +168,7 @@ export const useNavigation = ({
                         break
                 }
             } else {
-                if (activeSection === 'actions') {
+                if (activeSection === ACTIONS_SECTION) {
                     handleListViewNavigation({
                         event,
                         listLength: actionsLength,
@@ -179,7 +178,7 @@ export const useNavigation = ({
 
             if (event.key === 'Escape') {
                 event.preventDefault()
-                setOpenModal(false)
+                setModalOpen(false)
                 setActiveSection(defaultSection)
                 setHighlightedIndex(0)
             }
@@ -192,15 +191,14 @@ export const useNavigation = ({
             highlightedIndex,
             setActiveSection,
             setHighlightedIndex,
-            setOpenModal,
         ]
     )
 
     const handleKeyDown = useCallback(
         (event) => {
-            const modal = modalRef.current
+            const modal = modalRef.current.childNodes[0]
 
-            if (currentView === 'home') {
+            if (currentView === HOME_VIEW) {
                 if (filter.length > 0) {
                     // search mode
                     handleListViewNavigation({
@@ -219,7 +217,7 @@ export const useNavigation = ({
             }
 
             if (event.key === 'Enter') {
-                if (activeSection === 'actions') {
+                if (activeSection === ACTIONS_SECTION) {
                     modal
                         ?.querySelector('.actions-menu')
                         ?.childNodes?.[highlightedIndex]?.click()
@@ -240,7 +238,6 @@ export const useNavigation = ({
             highlightedIndex,
             itemsArray,
             setActiveSection,
-            setOpenModal,
             showGrid,
         ]
     )
@@ -249,7 +246,7 @@ export const useNavigation = ({
         handleKeyDown,
         goToDefaultView,
         modalRef,
-        activeSection,
-        setActiveSection,
+        setModalOpen,
+        showModal: modalOpen,
     }
 }

--- a/components/header-bar/src/command-palette/hooks/use-view-handler.js
+++ b/components/header-bar/src/command-palette/hooks/use-view-handler.js
@@ -1,0 +1,25 @@
+import { useCallback } from 'react'
+import { useCommandPaletteContext } from '../context/command-palette-context.js'
+import { HOME_VIEW } from '../utils/constants.js'
+
+const useViewHandler = ({ section }) => {
+    const { setHighlightedIndex, setFilter, setCurrentView, setActiveSection } =
+        useCommandPaletteContext()
+
+    const goToDefaultView = useCallback(() => {
+        setFilter('')
+        setCurrentView(HOME_VIEW)
+        setActiveSection(section)
+        setHighlightedIndex(0)
+    }, [
+        setActiveSection,
+        setCurrentView,
+        setFilter,
+        setHighlightedIndex,
+        section,
+    ])
+
+    return goToDefaultView
+}
+
+export default useViewHandler

--- a/components/header-bar/src/command-palette/sections/container.js
+++ b/components/header-bar/src/command-palette/sections/container.js
@@ -1,32 +1,21 @@
 import { colors, elevations } from '@dhis2/ui-constants'
-import { Layer } from '@dhis2-ui/layer'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { forwardRef } from 'react'
 
-const ModalContainer = ({
-    children,
-    setShow,
-    show,
-    modalRef,
-    onFocus,
-    onKeyDown,
-}) => {
+const ModalContainer = forwardRef(function ModalContainer(
+    { children, onFocus, onKeyDown },
+    ref
+) {
     return (
-        <Layer onBackdropClick={() => setShow(false)} translucent={show}>
-            <div
-                role="dialog"
-                aria-modal="true"
-                ref={modalRef}
-                tabIndex={0}
-                onFocus={onFocus}
-                onKeyDown={onKeyDown}
-            >
+        <>
+            <dialog ref={ref} onFocus={onFocus} onKeyDown={onKeyDown}>
                 {children}
-            </div>
+            </dialog>
             <style jsx>{`
-                div {
+                dialog {
                     display: flex;
                     flex-direction: column;
+                    border: none;
                     border-radius: 1px;
                     padding: 1px;
                     width: 572px;
@@ -38,15 +27,12 @@ const ModalContainer = ({
                     margin-top: 92px;
                 }
             `}</style>
-        </Layer>
+        </>
     )
-}
+})
 
 ModalContainer.propTypes = {
     children: PropTypes.node,
-    modalRef: PropTypes.object,
-    setShow: PropTypes.func,
-    show: PropTypes.bool,
     onFocus: PropTypes.func,
     onKeyDown: PropTypes.func,
 }

--- a/components/header-bar/src/command-palette/utils/constants.js
+++ b/components/header-bar/src/command-palette/utils/constants.js
@@ -13,3 +13,8 @@ export const APPS = 'APPS'
 export const COMMANDS = 'COMMANDS'
 export const SHORTCUTS = 'SHORTCUTS'
 export const LOGOUT = 'LOGOUT'
+
+// grid
+export const MIN_APPS_NUM = 8
+export const GRID_COLUMNS = 4
+export const GRID_ROWS = 2

--- a/components/header-bar/src/command-palette/utils/constants.js
+++ b/components/header-bar/src/command-palette/utils/constants.js
@@ -1,0 +1,15 @@
+// views
+export const HOME_VIEW = 'HOME'
+export const ALL_APPS_VIEW = 'APPS'
+export const ALL_COMMANDS_VIEW = 'COMMANDS'
+export const ALL_SHORTCUTS_VIEW = 'SHORTCUTS'
+
+// home section
+export const GRID_SECTION = 'GRID'
+export const ACTIONS_SECTION = 'ACTIONS'
+
+// action types
+export const APPS = 'APPS'
+export const COMMANDS = 'COMMANDS'
+export const SHORTCUTS = 'SHORTCUTS'
+export const LOGOUT = 'LOGOUT'

--- a/components/header-bar/src/command-palette/views/home-view.js
+++ b/components/header-bar/src/command-palette/views/home-view.js
@@ -8,6 +8,7 @@ import { useCommandPaletteContext } from '../context/command-palette-context.js'
 import AppItem from '../sections/app-item.js'
 import Heading from '../sections/heading.js'
 import ListItem from '../sections/list-item.js'
+import { ACTIONS_SECTION, GRID_SECTION, LOGOUT } from '../utils/constants.js'
 import ListView from './list-view.js'
 
 function HomeView({ apps, commands, shortcuts, actions }) {
@@ -51,11 +52,12 @@ function HomeView({ apps, commands, shortcuts, actions }) {
                                             path={defaultAction}
                                             img={icon}
                                             highlighted={
-                                                activeSection === 'grid' &&
+                                                activeSection ===
+                                                    GRID_SECTION &&
                                                 highlightedIndex === idx
                                             }
                                             handleMouseEnter={() => {
-                                                setActiveSection('grid')
+                                                setActiveSection(GRID_SECTION)
                                                 setHighlightedIndex(idx)
                                             }}
                                         />
@@ -72,7 +74,7 @@ function HomeView({ apps, commands, shortcuts, actions }) {
                         </>
                     )}
                     {/* actions menu */}
-                    <Heading heading={'Actions'} />
+                    <Heading heading={i18n.t('Actions')} />
                     <div
                         role="menu"
                         className="actions-menu"
@@ -102,7 +104,7 @@ function HomeView({ apps, commands, shortcuts, actions }) {
                                         icon={icon}
                                         dataTest={dataTest}
                                         href={
-                                            type === 'logout'
+                                            type === LOGOUT
                                                 ? joinPath(
                                                       baseUrl,
                                                       'dhis-web-commons-security/logout.action'
@@ -110,16 +112,16 @@ function HomeView({ apps, commands, shortcuts, actions }) {
                                                 : undefined
                                         }
                                         onClickHandler={
-                                            type === 'logout'
+                                            type === LOGOUT
                                                 ? logoutActionHandler
                                                 : viewActionHandler
                                         }
                                         highlighted={
-                                            activeSection === 'actions' &&
+                                            activeSection === ACTIONS_SECTION &&
                                             highlightedIndex === index
                                         }
                                         handleMouseEnter={() => {
-                                            setActiveSection('actions')
+                                            setActiveSection(ACTIONS_SECTION)
                                             setHighlightedIndex(index)
                                         }}
                                     />


### PR DESCRIPTION
This PR improves upon the implementation of the command palette navigation. 
- It abstracts part of the functionality in the general useNavigation hook into separate hooks
- It rebuilds the modal component with the [dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) element. 